### PR TITLE
(WIP) OpenCover Support (WIP)

### DIFF
--- a/tasks/opencover.js
+++ b/tasks/opencover.js
@@ -1,0 +1,13 @@
+exports.wrapCommand = function(command) {
+    var pathToOpencover = 'C:\\src\\moderator\\build\\bin\\opencover\\OpenCover.Console.exe';
+    var wrappedArgs = [];
+    wrappedArgs.push('-target:"' + command.path + '"');
+    wrappedArgs.push('-targetargs:"' + command.args.join(' ') + '"');
+    wrappedArgs.push('-register:user');
+    wrappedArgs.push('-output:_CodeCoverageResult.xml');
+
+    return {
+        path: pathToOpencover,
+        args: wrappedArgs
+    };
+};

--- a/tasks/opencover.js
+++ b/tasks/opencover.js
@@ -1,5 +1,5 @@
-exports.wrapCommand = function(command) {
-    var pathToOpencover = 'C:\\src\\moderator\\build\\bin\\opencover\\OpenCover.Console.exe';
+exports.wrapCommand = function(command, options) {
+    var pathToOpencover = options.coverPath;
     var wrappedArgs = [];
     wrappedArgs.push('-target:"' + command.path + '"');
     wrappedArgs.push('-targetargs:"' + command.args.join(' ') + '"');

--- a/tasks/opencover.js
+++ b/tasks/opencover.js
@@ -4,7 +4,21 @@ exports.wrapCommand = function(command, options) {
     wrappedArgs.push('-target:"' + command.path + '"');
     wrappedArgs.push('-targetargs:"' + command.args.join(' ') + '"');
     wrappedArgs.push('-register:user');
-    wrappedArgs.push('-output:_CodeCoverageResult.xml');
+    wrappedArgs.push('-returntargetcode');
+    
+    var coverReportFilePath = '_CodeCoverageResult.xml';
+    if (options.coverReportFilePath && options.coverReportFilePath !== '') {
+        coverReportFilePath = '"' + options.coverReportFilePath + '"';
+    }
+    wrappedArgs.push('-output:' + coverReportFilePath);
+
+    if (options.coverFilter && options.coverFilter !== '') {
+        wrappedArgs.push('-filter:"' + options.coverFilter + '"');
+    }
+
+    if (options.coverExcludeAttributeFilter && options.coverExcludeAttributeFilter !== '') {
+        wrappedArgs.push('-excludebyattribute:"' + options.coverExcludeAttributeFilter + '"');
+    }
 
     return {
         path: pathToOpencover,

--- a/tasks/task.js
+++ b/tasks/task.js
@@ -1,7 +1,8 @@
 var path = require('path'),
     temp = require('temp'),
     process = require('child_process'),
-    nunit = require('./nunit.js');
+    nunit = require('./nunit.js'),
+    opencover = require('./opencover.js');
 
 module.exports = function(grunt) {
 
@@ -22,6 +23,10 @@ module.exports = function(grunt) {
 
         var assemblies = nunit.findTestAssemblies(this.filesSrc, options);
         var command = nunit.buildCommand(assemblies, options);
+        
+        if (options.cover) {
+            command = opencover.wrapCommand(command);
+        }
 
         console.log('Running tests in:');
         console.log();
@@ -47,7 +52,7 @@ module.exports = function(grunt) {
         });  
 
         nunitProcess.on('error', function(e) { 
-            grunt.fail.fatal(e.code === 'ENOENT' ? 'Unable to find NUnit Console.exe located at ' + command.path : e.message);
+            grunt.fail.fatal(e.code === 'ENOENT' ? 'Unable to find executable located at ' + command.path : e.message);
         });     
     });
 };

--- a/tasks/task.js
+++ b/tasks/task.js
@@ -25,7 +25,7 @@ module.exports = function(grunt) {
         var command = nunit.buildCommand(assemblies, options);
         
         if (options.cover) {
-            command = opencover.wrapCommand(command);
+            command = opencover.wrapCommand(command, options);
         }
 
         console.log('Running tests in:');


### PR DESCRIPTION
I want to use NUnit wrapped in OpenCover so that code coverage reports would be available. Because of the tight coupling of a) generating the NUnit command and b) executing it within a Grunt task, this pull request current is the only way of injecting OpenCover support (apart from duplicating everything here).

What do you think? Specifically about this but also about the approach to the problem I have.